### PR TITLE
Fixed an issue where inline formatting would cause the delete key to …

### DIFF
--- a/src/core/main/ts/delete/InlineFormatDelete.ts
+++ b/src/core/main/ts/delete/InlineFormatDelete.ts
@@ -52,7 +52,7 @@ const deleteCaret = function (editor, forward) {
 
   return Arr.last(parentInlines).map(function (target) {
     const fromPos = CaretPosition.fromRangeStart(editor.selection.getRng());
-    if (DeleteUtils.willDeleteLastPositionInElement(forward, fromPos, target.dom())) {
+    if (DeleteUtils.willDeleteLastPositionInElement(forward, fromPos, target.dom()) && !CaretFormat.isEmptyCaretFormatElement(target)) {
       deleteLastPosition(forward, editor, target, parentInlines);
       return true;
     } else {

--- a/src/core/main/ts/fmt/CaretFormat.ts
+++ b/src/core/main/ts/fmt/CaretFormat.ts
@@ -21,8 +21,9 @@ import SplitRange from '../selection/SplitRange';
 import Zwsp from '../text/Zwsp';
 import Fun from '../util/Fun';
 import { Selection } from '../api/dom/Selection';
-import { Editor } from 'tinymce/core/api/Editor';
+import { Editor } from '../api/Editor';
 import { isCaretNode, getParentCaretContainer } from './FormatContainer';
+import DeleteElement from "../delete/DeleteElement";
 
 const ZWSP = Zwsp.ZWSP, CARET_ID = '_mce_caret';
 
@@ -95,20 +96,17 @@ const trimZwspFromCaretContainer = function (caretContainerNode) {
   return textNode;
 };
 
-const removeCaretContainerNode = function (dom, selection, node, moveCaret) {
-  let rng, block, textNode;
-
-  rng = selection.getRng(true);
-  block = dom.getParent(node, dom.isBlock);
+const removeCaretContainerNode = function (editor, node, moveCaret) {
+  const dom = editor.dom, selection = editor.selection;
 
   if (isCaretContainerEmpty(node)) {
-    if (moveCaret !== false) {
-      rng.setStartBefore(node);
-      rng.setEndBefore(node);
-    }
-
-    dom.remove(node);
+    DeleteElement.deleteElement(editor, false, Element.fromDom(node), moveCaret);
   } else {
+    let rng, block, textNode;
+
+    rng = selection.getRng();
+    block = dom.getParent(node, dom.isBlock);
+
     textNode = trimZwspFromCaretContainer(node);
     if (rng.startContainer === textNode && rng.startOffset > 0) {
       rng.setStart(textNode, rng.startOffset - 1);
@@ -119,27 +117,28 @@ const removeCaretContainerNode = function (dom, selection, node, moveCaret) {
     }
 
     dom.remove(node, true);
-  }
 
-  if (block && dom.isEmpty(block)) {
-    PaddingBr.fillWithPaddingBr(Element.fromDom(block));
-  }
+    if (block && dom.isEmpty(block)) {
+      PaddingBr.fillWithPaddingBr(Element.fromDom(block));
+    }
 
-  selection.setRng(rng);
+    selection.setRng(rng);
+  }
 };
 
 // Removes the caret container for the specified node or all on the current document
-const removeCaretContainer = function (body, dom, selection: Selection, node, moveCaret?) {
+const removeCaretContainer = function (editor, node, moveCaret?) {
+  const dom = editor.dom, selection = editor.selection;
   if (!node) {
-    node = getParentCaretContainer(body, selection.getStart());
+    node = getParentCaretContainer(editor.getBody(), selection.getStart());
 
     if (!node) {
       while ((node = dom.get(CARET_ID))) {
-        removeCaretContainerNode(dom, selection, node, false);
+        removeCaretContainerNode(editor, node, false);
       }
     }
   } else {
-    removeCaretContainerNode(dom, selection, node, moveCaret);
+    removeCaretContainerNode(editor, node, moveCaret);
   }
 };
 
@@ -286,7 +285,7 @@ const removeCaretFormat = function (editor: Editor, name, vars, similar) {
       insertCaretContainerNode(editor, newCaretContainer, formatNode);
     }
 
-    removeCaretContainerNode(dom, selection, caretContainer, false);
+    removeCaretContainerNode(editor, caretContainer, false);
     selection.setCursorLocation(caretNode, 1);
 
     if (dom.isEmpty(formatNode)) {
@@ -295,26 +294,25 @@ const removeCaretFormat = function (editor: Editor, name, vars, similar) {
   }
 };
 
-const disableCaretContainer = function (body, dom, selection: Selection, keyCode) {
-  removeCaretContainer(body, dom, selection, null, false);
+const disableCaretContainer = function (editor, keyCode) {
+  const selection = editor.selection, body = editor.getBody();
+
+  removeCaretContainer(editor, null, false);
 
   // Remove caret container if it's empty
-  if (keyCode === 8 && selection.isCollapsed() && selection.getStart().innerHTML === ZWSP) {
-    removeCaretContainer(body, dom, selection, getParentCaretContainer(body, selection.getStart()));
+  if ((keyCode === 8 || keyCode == 46) && selection.isCollapsed() && selection.getStart().innerHTML === ZWSP) {
+    removeCaretContainer(editor, getParentCaretContainer(body, selection.getStart()));
   }
 
   // Remove caret container on keydown and it's left/right arrow keys
   if (keyCode === 37 || keyCode === 39) {
-    removeCaretContainer(body, dom, selection, getParentCaretContainer(body, selection.getStart()));
+    removeCaretContainer(editor, getParentCaretContainer(body, selection.getStart()));
   }
 };
 
 const setup = function (editor) {
-  const dom = editor.dom, selection = editor.selection;
-  const body = editor.getBody();
-
   editor.on('mouseup keydown', function (e) {
-    disableCaretContainer(body, dom, selection, e.keyCode);
+    disableCaretContainer(editor, e.keyCode);
   });
 };
 
@@ -332,10 +330,15 @@ const isFormatElement = function (editor, element) {
   return inlineElements.hasOwnProperty(Node.name(element)) && !isCaretNode(element.dom()) && !NodeType.isBogus(element.dom());
 };
 
+const isEmptyCaretFormatElement = function (element) {
+  return isCaretNode(element.dom()) && isCaretContainerEmpty(element.dom());
+};
+
 export {
   setup,
   applyCaretFormat,
   removeCaretFormat,
   replaceWithCaretFormat,
-  isFormatElement
+  isFormatElement,
+  isEmptyCaretFormatElement
 };

--- a/src/core/test/ts/browser/delete/DeleteElementTest.ts
+++ b/src/core/test/ts/browser/delete/DeleteElementTest.ts
@@ -163,6 +163,41 @@ UnitTest.asynctest('browser.tinymce.core.delete.DeleteElementTest', function () 
         sDeleteElementPath(editor, false, [0, 1]),
         tinyApis.sAssertContent('<p>ab</p>'),
         tinyApis.sAssertSelection([0, 0], 1, [0, 0], 1)
+      ])),
+      Logger.t('Delete inline element adjacent text nodes forwards', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p>a <strong>b</strong> c</p>'),
+        tinyApis.sSetCursor([0, 0], 2),
+        sDeleteElementPath(editor, true, [0, 1]),
+        tinyApis.sAssertContent('<p>a &nbsp;c</p>'),
+        tinyApis.sAssertSelection([0, 0], 2, [0, 0], 2)
+      ])),
+      Logger.t('Delete inline element adjacent text nodes backwards', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p>a&nbsp; <strong>b</strong> &nbsp;c</p>'),
+        tinyApis.sSetCursor([0, 2], 0),
+        sDeleteElementPath(editor, false, [0, 1]),
+        tinyApis.sAssertContent('<p>a &nbsp; &nbsp;c</p>'),
+        tinyApis.sAssertSelection([0, 0], 3, [0, 0], 3)
+      ])),
+      Logger.t('Delete inline element adjacent text nodes, single space', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p>a <strong>b</strong>c</p>'),
+        tinyApis.sSetCursor([0, 1], 0),
+        sDeleteElementPath(editor, false, [0, 1]),
+        tinyApis.sAssertContent('<p>a c</p>'),
+        tinyApis.sAssertSelection([0, 0], 2, [0, 0], 2)
+      ])),
+      Logger.t('Delete inline element leading only text nodes', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p>a <strong>b</strong></p>'),
+        tinyApis.sSetCursor([0, 1], 0),
+        sDeleteElementPath(editor, false, [0, 1]),
+        tinyApis.sAssertContent('<p>a&nbsp;</p>'),
+        tinyApis.sAssertSelection([0, 0], 2, [0, 0], 2)
+      ])),
+      Logger.t('Delete inline element trailing only text nodes', GeneralSteps.sequence([
+        tinyApis.sSetContent('<p><strong>a</strong> b</p>'),
+        tinyApis.sSetCursor([0, 1], 0),
+        sDeleteElementPath(editor, false, [0, 0]),
+        tinyApis.sAssertContent('<p>&nbsp;b</p>'),
+        tinyApis.sAssertSelection([0, 0], 0, [0, 0], 0)
       ]))
     ], onSuccess, onFailure);
   }, {

--- a/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
+++ b/src/core/test/ts/browser/delete/InlineFormatDeleteTest.ts
@@ -72,6 +72,39 @@ UnitTest.asynctest('browser.tinymce.core.delete.InlineFormatDelete', function ()
           sDeleteNoop(editor),
           tinyApis.sAssertContent('<p>ab</p>'),
           tinyApis.sAssertSelection([0, 0], 1, [0, 0], 1)
+        ])),
+        Logger.t('Delete in middle of caret format span should do nothing', GeneralSteps.sequence([
+          tinyApis.sSetRawContent('<p>a<span id="_mce_caret" data-mce-bogus="1" data-mce-type="format-caret"><strong>&#65279;</strong></span>b</p>'),
+          tinyApis.sSetCursor([0, 1], 0),
+          sDeleteNoop(editor),
+          tinyApis.sAssertSelection([0, 1], 0, [0, 1], 0),
+          tinyApis.sAssertContentStructure(
+            ApproxStructure.build(function (s, str, arr) {
+              return s.element('body', {
+                children: [
+                  s.element('p', {
+                    children: [
+                      s.text(str.is('a')),
+                      s.element('span', {
+                        attrs: {
+                          'id': str.is('_mce_caret'),
+                          'data-mce-bogus': str.is('1')
+                        },
+                        children: [
+                          s.element('strong', {
+                            children: [
+                              s.text(str.is(Zwsp.ZWSP))
+                            ]
+                          })
+                        ]
+                      }),
+                      s.text(str.is('b')),
+                    ]
+                  })
+                ]
+              });
+            })
+          )
         ]))
       ])),
       Logger.t('Backspace/delete in at last character', GeneralSteps.sequence([


### PR DESCRIPTION
Fixes #4572

This fixes an issue whereby pressing the delete key when it got to the end of any inline formatting would get stuck and wouldn't delete anymore content. I also fixed an issue where when the caret format marker/span was removed (or any inline element for that matter), it'd inadvertently lose relevant spaces when it shouldn't have (due to the browser collapsing the whitespace). I fixed this by updating the logic to work in a similar way to blink/webkit, whereby when the inline element is removed, it'll normalize the spaces by swapping between a regular space and a non-breaking space.

Note: This relates to 1780be9a4079771f8b451e3e28f888994c6356f9 which added a fix to preserve the formatting state when the last char was deleted.